### PR TITLE
Add SSM param to identify WAF-protected load balancer

### DIFF
--- a/cdk/lib/__snapshots__/gatehouse.test.ts.snap
+++ b/cdk/lib/__snapshots__/gatehouse.test.ts.snap
@@ -71,6 +71,25 @@ exports[`The Gatehouse stack matches the snapshot 1`] = `
     },
   },
   "Resources": {
+    "AlbSsmParam485C1D52": {
+      "Properties": {
+        "DataType": "text",
+        "Description": "The ARN of the ALB for identity-TEST-gatehouse. N.B. This parameter is created via CDK.",
+        "Name": "/infosec/waf/services/TEST/gatehouse-alb-arn",
+        "Tags": {
+          "Stack": "identity",
+          "Stage": "TEST",
+          "gu:cdk:version": "TEST",
+          "gu:repo": "guardian/gatehouse",
+        },
+        "Tier": "Standard",
+        "Type": "String",
+        "Value": {
+          "Ref": "LoadBalancerGatehouse6031E987",
+        },
+      },
+      "Type": "AWS::SSM::Parameter",
+    },
     "AutoScalingGroupGatehouseASG9482EAEF": {
       "Properties": {
         "HealthCheckGracePeriod": 120,

--- a/cdk/lib/gatehouse.ts
+++ b/cdk/lib/gatehouse.ts
@@ -7,6 +7,7 @@ import {GuPolicy, ReadParametersByName} from "@guardian/cdk/lib/constructs/iam";
 import type {App} from 'aws-cdk-lib';
 import {Duration} from 'aws-cdk-lib';
 import {InstanceClass, InstanceSize, InstanceType} from 'aws-cdk-lib/aws-ec2';
+import {ParameterDataType, ParameterTier, StringParameter} from "aws-cdk-lib/aws-ssm";
 
 export interface GatehouseStackProps extends GuStackProps {
     domainName: string;
@@ -52,6 +53,16 @@ export class Gatehouse extends GuStack {
             roleConfiguration: {
                 additionalPolicies: [readAppSsmParamsPolicy],
             },
+        });
+
+        // This parameter is used by https://github.com/guardian/waf
+        new StringParameter(this, "AlbSsmParam", {
+            parameterName: `/infosec/waf/services/${this.stage}/gatehouse-alb-arn`,
+            description: `The ARN of the ALB for identity-${this.stage}-gatehouse. N.B. This parameter is created via CDK.`,
+            simpleName: false,
+            stringValue: loadBalancer.loadBalancerArn,
+            tier: ParameterTier.STANDARD,
+            dataType: ParameterDataType.TEXT,
         });
 
         new GuCname(this, 'EC2AppDNS', {


### PR DESCRIPTION
This is preparation for adding the load balancer to the list of resources protected by the Identity WAF.

Once we've set up the Identity WAF, which is done in https://github.com/guardian/waf/pull/42, [this code](https://github.com/guardian/waf/blob/49869ab9a2eddaccdf52682111214ce1aaeb38e8/lib/primary-waf.ts#L32-L43) will look up the [ARN](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference-arns.html) of protected load balancers in the Identity account SSM parameters.
