### PR TITLE
Give Snyk workflow the correct location of .nvmrc

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -11,5 +11,6 @@ jobs:
     uses: guardian/.github/.github/workflows/sbt-node-snyk.yml@main
     with:
       ORG: guardian-identity
+      NODE_VERSION_FILE: cdk/.nvmrc
     secrets:
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}


### PR DESCRIPTION
A [workflow run](https://github.com/guardian/gatehouse/actions/runs/7653792838/job/20856405677#step:4:8) failed because `.nvmrc` isn't where it was expected to be.