### PR TITLE
Exclude old Play dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,5 +23,9 @@ lazy val root = (project in file("."))
     dependencyOverrides ++= Seq(
       // To keep all Jackson dependencies on the same version
       "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.15.2" % Runtime,
-    )
+    ),
+    excludeDependencies ++= Seq(
+      // As of Play 3.0, groupId has changed to org.playframework; exclude transitive dependencies to the old artifacts
+      ExclusionRule(organization = "com.typesafe.play")
+    ),
   )


### PR DESCRIPTION
Copying guardian/prism#791

This does eliminate several duplicate libraries that were pulled in from v2.9.0 and from v3.0.1.