### PR TITLE
Use Code Okta org locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,9 @@ the `conf` directory. These might be values that we expose in browsers, for exam
 
 Finally, settings that aren't private and are the same for all deployment stages are set in the `conf/application.conf`
 file.
+
+### Okta-specific configuration
+
+TODO: Instructions on how to generate an Okta access token locally.     
+We use the Okta Code org locally because this makes it easier to develop and test with users that have already been
+registered in [Code gateway](https://profile.code.dev-theguardian.com/).

--- a/app/load/AppComponents.scala
+++ b/app/load/AppComponents.scala
@@ -29,8 +29,8 @@ class AppComponents(context: Context)
 
   private lazy val oktaOrgUrl = s"https://${configuration.get[String]("oktaApi.domain")}"
 
-  private lazy val oktaApiClient =
-    Clients
+  private lazy val oktaUserApi = {
+    val apiClient = Clients
       .builder()
       .setOrgUrl(oktaOrgUrl)
       .setClientId(configuration.get[String]("oktaApi.clientId"))
@@ -38,6 +38,8 @@ class AppComponents(context: Context)
       .setPrivateKey(configuration.get[String]("oktaApi.privateKey"))
       .setScopes(configuration.get[Seq[String]]("oktaApi.scopes").toSet.asJava)
       .build()
+    new UserApi(apiClient)
+  }
 
   private lazy val authService = OktaAuthService(
     OktaTokenValidationConfig(
@@ -51,7 +53,7 @@ class AppComponents(context: Context)
     slickApi.dbConfig[JdbcProfile](DbName("legacyIdentityDb"))
   )
 
-  private lazy val oktaUserService = new OktaUserService(new UserApi(oktaApiClient), oktaOrgUrl, wsClient)
+  private lazy val oktaUserService = new OktaUserService(oktaUserApi, oktaOrgUrl, wsClient)
 
   private lazy val userService = new CompositeUserService(oktaUserService, legacyIdentityDbUserService)
 

--- a/conf/DEV.conf
+++ b/conf/DEV.conf
@@ -1,7 +1,8 @@
 include "application.conf"
 
 idProvider {
-  audience = "https://profile.thegulocal.com/"
+  issuer = "https://profile.code.dev-theguardian.com/oauth2/aus3v9gla95Toj0EE0x7"
+  audience = "https://profile.code.dev-theguardian.com/"
 }
 
 slick.dbs.legacyIdentityDb {


### PR DESCRIPTION
This change makes it easier to work locally by using Code env for Gateway and Okta.

I've also changed the values of these SSM parameters so that Dev now uses the same as Code:
* /DEV/identity/gatehouse/oktaApi/domain
* /DEV/identity/gatehouse/oktaApi/clientId
* /DEV/identity/gatehouse/oktaApi/privateKey
