### PR TITLE
Allow AuthorisedAction to parse any request content

### DIFF
--- a/app/auth/AuthorisedAction.scala
+++ b/app/auth/AuthorisedAction.scala
@@ -13,12 +13,14 @@ import scala.concurrent.{ExecutionContext, Future}
   * the action returns a 401 Unauthorized response. If the token is valid but doesn't have the required scopes, the
   * action returns a 403 Forbidden response.
   */
-class AuthorisedAction(oktaAuthService: OktaAuthService, requiredScopes: List[AccessScope])(implicit
+class AuthorisedAction(
+    oktaAuthService: OktaAuthService,
+    val parser: BodyParser[AnyContent],
+    requiredScopes: List[AccessScope]
+)(implicit
     val executionContext: ExecutionContext
 ) extends ActionBuilder[RequestWithClaims, AnyContent]
     with ActionRefiner[Request, RequestWithClaims] {
-
-  def parser: BodyParser[AnyContent] = BodyParsers.utils.ignore(AnyContentAsEmpty: AnyContent)
 
   protected def refine[A](request: Request[A]): Future[Either[Result, RequestWithClaims[A]]] = {
     Helpers.fetchBearerTokenFromAuthHeader(request.headers.get) match {

--- a/app/load/AppComponents.scala
+++ b/app/load/AppComponents.scala
@@ -57,7 +57,7 @@ class AppComponents(context: Context)
 
   private lazy val userService = new CompositeUserService(oktaUserService, legacyIdentityDbUserService)
 
-  private lazy val authorisedAction = new AuthorisedAction(authService, _)
+  private lazy val authorisedAction = new AuthorisedAction(authService, playBodyParsers.defaultBodyParser, _)
 
   private lazy val healthCheckController = new HealthCheckController(controllerComponents, userService)
 

--- a/test/auth/AuthorisedActionSpec.scala
+++ b/test/auth/AuthorisedActionSpec.scala
@@ -2,10 +2,12 @@ package auth
 
 import cats.effect.IO
 import com.gu.identity.auth.*
+import org.apache.pekko.stream.testkit.NoMaterializer
 import org.mockito.Mockito.when
 import org.scalatest.matchers.should.Matchers.shouldBe
 import org.scalatestplus.mockito.MockitoSugar.mock
 import org.scalatestplus.play.*
+import play.api.libs.json.Json
 import play.api.mvc.*
 import play.api.mvc.Results.*
 import play.api.test.*
@@ -23,7 +25,8 @@ class AuthorisedActionSpec extends PlaySpec {
 
     "return 401 when there is no Authorization header" in {
       val authService = mock[OktaAuthService]
-      val action = new AuthorisedAction(authService, requiredScopes)
+      val bodyParser = mock[BodyParser[AnyContent]]
+      val action = new AuthorisedAction(authService, bodyParser, requiredScopes)
       val request = FakeRequest(GET, "/")
       val result = action(Ok)(request)
       status(result) shouldBe UNAUTHORIZED
@@ -35,7 +38,8 @@ class AuthorisedActionSpec extends PlaySpec {
       val authService = mock[OktaAuthService]
       when(authService.validateAccessToken(AccessToken("invalidToken"), requiredScopes))
         .thenReturn(IO.raiseError(OktaValidationException(InvalidOrExpiredToken)))
-      val action = new AuthorisedAction(authService, requiredScopes)
+      val bodyParser = mock[BodyParser[AnyContent]]
+      val action = new AuthorisedAction(authService, bodyParser, requiredScopes)
       val request = FakeRequest(GET, "/").withHeaders("Authorization" -> "Bearer invalidToken")
       val result = action(Ok)(request)
       status(result) shouldBe UNAUTHORIZED
@@ -47,7 +51,8 @@ class AuthorisedActionSpec extends PlaySpec {
       val authService = mock[OktaAuthService]
       when(authService.validateAccessToken(AccessToken("validToken"), requiredScopes))
         .thenReturn(IO.raiseError(OktaValidationException(MissingRequiredScope(requiredScopes))))
-      val action = new AuthorisedAction(authService, requiredScopes)
+      val bodyParser = mock[BodyParser[AnyContent]]
+      val action = new AuthorisedAction(authService, bodyParser, requiredScopes)
       val request = FakeRequest(GET, "/").withHeaders("Authorization" -> "Bearer validToken")
       val result = action(Ok)(request)
       status(result) shouldBe FORBIDDEN
@@ -56,18 +61,28 @@ class AuthorisedActionSpec extends PlaySpec {
     }
 
     "return 200 when the token is valid and has the required scopes" in {
-      val requiredScopes = List(new AccessScope {
-        override def name: String = "requiredScope"
-      })
       val authService = mock[OktaAuthService]
       when(authService.validateAccessToken(AccessToken("validToken"), requiredScopes))
         .thenReturn(
           IO.pure(DefaultAccessClaims(primaryEmailAddress = "a@b.com", identityId = "I43", username = None))
         )
-      val action = new AuthorisedAction(authService, requiredScopes)
+      val bodyParser = mock[BodyParser[AnyContent]]
+      val action = new AuthorisedAction(authService, bodyParser, requiredScopes)
       val request = FakeRequest(GET, "/").withHeaders("Authorization" -> "Bearer validToken")
       val result = action(Ok)(request)
       status(result) shouldBe OK
+    }
+
+    "parse the request body correctly" in {
+      val requestBody = Json.obj("key" -> "value")
+      val request = FakeRequest(POST, "/").withHeaders("Authorization" -> "Bearer validToken").withJsonBody(requestBody)
+      val authService = mock[OktaAuthService]
+      val bodyParser = stubBodyParser(AnyContentAsJson(requestBody))
+      val action = new AuthorisedAction(authService, bodyParser, requiredScopes)
+      await(action.parser(request).run()(NoMaterializer)) match {
+        case Left(result)   => fail(s"Request body parsing failed: $result")
+        case Right(content) => content mustBe AnyContentAsJson(Json.obj("key" -> "value"))
+      }
     }
   }
 }

--- a/test/controllers/HealthCheckControllerSpec.scala
+++ b/test/controllers/HealthCheckControllerSpec.scala
@@ -2,7 +2,6 @@ package controllers
 
 import load.AppComponents
 import org.mockito.Mockito.when
-import org.scalatest.matchers.should.Matchers.shouldBe
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.*
 import org.scalatestplus.play.components.OneAppPerTestWithComponents
@@ -27,9 +26,9 @@ class HealthCheckControllerSpec extends PlaySpec with OneAppPerTestWithComponent
       when(userService.healthCheck()).thenReturn(Future.successful(()))
       val controller = new HealthCheckController(stubControllerComponents(), userService)
       val healthCheck = controller.healthCheck().apply(FakeRequest(GET, path))
-      status(healthCheck) shouldBe OK
-      contentType(healthCheck) shouldBe Some("text/plain")
-      contentAsString(healthCheck) shouldBe "OK"
+      status(healthCheck) mustBe OK
+      contentType(healthCheck) mustBe Some("text/plain")
+      contentAsString(healthCheck) mustBe "OK"
     }
   }
 }

--- a/test/logging/LogEntrySpec.scala
+++ b/test/logging/LogEntrySpec.scala
@@ -1,6 +1,5 @@
 package logging
 
-import org.scalatest.matchers.should.Matchers.shouldBe
 import org.scalatestplus.play.*
 import play.api.mvc.Results.Ok
 import play.api.test.*
@@ -12,10 +11,10 @@ class LogEntrySpec extends PlaySpec {
     val request = FakeRequest(GET, "/").withHeaders(REFERER -> "Referrer")
     val entry = LogEntry.requestAndResponse(request, response = Ok.withHeaders(CONTENT_LENGTH -> "11"), duration = 7)
     "give correct message" in {
-      entry.message shouldBe """127.0.0.1 - "GET / HTTP/1.1" 200 11 "Referrer" 7ms"""
+      entry.message mustBe """127.0.0.1 - "GET / HTTP/1.1" 200 11 "Referrer" 7ms"""
     }
     "give correct fields" in {
-      entry.otherFields shouldBe Map(
+      entry.otherFields mustBe Map(
         "type" -> "access",
         "origin" -> "127.0.0.1",
         "referrer" -> "Referrer",
@@ -33,10 +32,10 @@ class LogEntrySpec extends PlaySpec {
     val request = FakeRequest(GET, "/").withHeaders(REFERER -> "Referrer")
     val entry = LogEntry.error(request, duration = 17)
     "give correct message" in {
-      entry.message shouldBe """127.0.0.1 - "GET / HTTP/1.1" ERROR "Referrer" 17ms"""
+      entry.message mustBe """127.0.0.1 - "GET / HTTP/1.1" ERROR "Referrer" 17ms"""
     }
     "give correct fields" in {
-      entry.otherFields shouldBe Map(
+      entry.otherFields mustBe Map(
         "type" -> "access",
         "origin" -> "127.0.0.1",
         "referrer" -> "Referrer",

--- a/test/services/OktaUserServiceSpec.scala
+++ b/test/services/OktaUserServiceSpec.scala
@@ -8,10 +8,9 @@ import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import play.api.libs.ws.WSClient
+import play.api.test.Helpers.*
 
-import scala.concurrent.Await
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.duration.Duration
 import scala.jdk.CollectionConverters.*
 import scala.util.Failure
 
@@ -49,7 +48,7 @@ class OktaUserServiceSpec extends PlaySpec with MockitoSugar {
       )
 
       val result = oktaUserService.fetchUserByOktaId("oktaId")
-      Await.result(result, Duration.Inf) mustBe Some(user)
+      await(result) mustBe Some(user)
     }
 
     "give no user when one doesn't exist" in {
@@ -61,7 +60,7 @@ class OktaUserServiceSpec extends PlaySpec with MockitoSugar {
       val oktaUserService = new OktaUserService(userApi, "orgUrl", mock[WSClient])
 
       val result = oktaUserService.fetchUserByOktaId("oktaId")
-      Await.result(result, Duration.Inf) mustBe None
+      await(result) mustBe None
     }
 
     "give a failed future when API fails" in {


### PR DESCRIPTION
Previously we were ignoring the body of requests.  
Now we feed the Play `defaultBodyParser` through from `AppComponents` so that `AnyContent` can be parsed.

This PR also includes some trivial changes to other test classes to avoid bringing in extra imports.
