### PR TITLE
Use gatehouse-specific access scope

### DIFF
--- a/app/auth/AccessScopes.scala
+++ b/app/auth/AccessScopes.scala
@@ -5,6 +5,6 @@ import com.gu.identity.auth.AccessScope
 object AccessScopes {
 
   case object UserReadSelfSecure extends AccessScope {
-    val name = "guardian.identity-api.user.read.self.secure"
+    val name = "guardian.gatehouse.user.read.self.secure"
   }
 }


### PR DESCRIPTION
Okta now has a set of Gatehouse-specific scopes that we can use to distinguish from Identity API access.