### PR TITLE
Don't leak information when access token validation fails

### DIFF
--- a/app/logging/LogEntry.scala
+++ b/app/logging/LogEntry.scala
@@ -2,6 +2,7 @@ package logging
 
 import play.api.http.HeaderNames.*
 import play.api.mvc.{RequestHeader, Result}
+import utils.RequestHelper.origin
 
 case class LogEntry(message: String, otherFields: Map[String, Any])
 
@@ -10,7 +11,7 @@ private[logging] object LogEntry {
   private def commonFields(request: RequestHeader, duration: Long) =
     Map(
       "type" -> "access",
-      "origin" -> request.headers.get(X_FORWARDED_FOR).getOrElse(request.remoteAddress),
+      "origin" -> origin(request),
       "referrer" -> request.headers.get(REFERER).getOrElse(""),
       "method" -> request.method,
       "duration" -> duration,

--- a/app/utils/RequestHelper.scala
+++ b/app/utils/RequestHelper.scala
@@ -1,0 +1,9 @@
+package utils
+
+import play.api.http.HeaderNames.X_FORWARDED_FOR
+import play.api.mvc.RequestHeader
+
+object RequestHelper {
+
+  def origin(request: RequestHeader): String = request.headers.get(X_FORWARDED_FOR).getOrElse(request.remoteAddress)
+}

--- a/test/auth/AuthorisedActionSpec.scala
+++ b/test/auth/AuthorisedActionSpec.scala
@@ -44,7 +44,7 @@ class AuthorisedActionSpec extends PlaySpec {
       val result = action(Ok)(request)
       status(result) shouldBe UNAUTHORIZED
       contentType(result) shouldBe Some("text/plain")
-      contentAsString(result) shouldBe "Token is invalid or expired"
+      contentAsString(result) shouldBe "Access token validation failed."
     }
 
     "return 403 when the token is valid but doesn't have the required scopes" in {
@@ -57,7 +57,7 @@ class AuthorisedActionSpec extends PlaySpec {
       val result = action(Ok)(request)
       status(result) shouldBe FORBIDDEN
       contentType(result) shouldBe Some("text/plain")
-      contentAsString(result) shouldBe "Token is missing required scope(s): requiredScope"
+      contentAsString(result) shouldBe "Access token validation failed."
     }
 
     "return 200 when the token is valid and has the required scopes" in {


### PR DESCRIPTION
Now when there's a validation failure we log the failure rather than outputting it as the response body.
This will hopefully help us to see if there's some general configuration error on a particular endpoint or if there's a problematic client.