### PR TITLE
Upgrade to Java 21

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,7 @@ jobs:
       # Java is needed for the Scala Play app
       - uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: 21
           distribution: corretto
           cache: sbt
 

--- a/cdk/.tool-versions
+++ b/cdk/.tool-versions
@@ -1,0 +1,1 @@
+java corretto-21.0.2.13.1

--- a/cdk/lib/gatehouse.ts
+++ b/cdk/lib/gatehouse.ts
@@ -55,7 +55,7 @@ export class Gatehouse extends GuStack {
                 enabled: true,
                 systemdUnitName: 'gatehouse'
             },
-            imageRecipe: 'arm-identity-base-jammy-java11-cdk-base',
+            imageRecipe: 'arm-identity-base-jammy-java21-cdk-base',
             roleConfiguration: {
                 additionalPolicies: [readAppSsmParamsPolicy],
             },


### PR DESCRIPTION
Following the [recommendation to use Java 21](https://github.com/guardian/recommendations/blob/485efca818bfe611a46dd9fefe183273c0346202/scala.md?plain=1#L9) as it's the latest LTS version.

Tested on Code.