### PR TITLE
Bug fix: extra quotes around username in user/me response

### DIFF
--- a/app/services/LegacyIdentityDbUserService.scala
+++ b/app/services/LegacyIdentityDbUserService.scala
@@ -27,7 +27,7 @@ class LegacyIdentityDbUserService(val dbConfig: DatabaseConfig[JdbcProfile])(imp
 
   def fetchUserByIdentityId(id: String): Future[Option[LegacyUser]] =
     db.run(
-      sql"SELECT id, okta_id, braze_uuid, jdoc->'publicFields'->'username', jdoc->'consents' FROM users WHERE id = $id LIMIT 1"
+      sql"SELECT id, okta_id, braze_uuid, jdoc->'publicFields'->>'username', jdoc->'consents' FROM users WHERE id = $id LIMIT 1"
         .as[(String, Option[String], Option[String], Option[String], String)]
     ).map(_.map { case (identityId, oktaId, brazeId, userName, permissionsJsonStr) =>
       LegacyUser(identityId, oktaId, brazeId, userName, toPermissions(permissionsJsonStr))


### PR DESCRIPTION
The username field was being queried as a json object instead of a string