### PR TITLE
update identity lib version and use the okta id claim instead of the legacy id to identify users

### DIFF
--- a/app/auth/RequestWithClaims.scala
+++ b/app/auth/RequestWithClaims.scala
@@ -1,6 +1,9 @@
 package auth
 
-import com.gu.identity.auth.DefaultAccessClaims
+import com.gu.identity.auth.{DefaultAccessClaims, DefaultIdentityClaims, OktaAuthenticatedUserInfo}
 import play.api.mvc.{Request, WrappedRequest}
 
-class RequestWithClaims[A](val claims: DefaultAccessClaims, request: Request[A]) extends WrappedRequest[A](request)
+class RequestWithClaims[A](
+    val userInfo: OktaAuthenticatedUserInfo[DefaultIdentityClaims, DefaultAccessClaims],
+    request: Request[A]
+) extends WrappedRequest[A](request)

--- a/app/controllers/UserController.scala
+++ b/app/controllers/UserController.scala
@@ -20,9 +20,9 @@ class UserController(
 )(implicit ex: ExecutionContext)
     extends BaseController {
 
-  def me(): Action[AnyContent] = authorisedAction(List(UserReadSelfSecure)).async(request =>
+  def me(): Action[AnyContent] = authorisedAction(List(UserReadSelfSecure)).async(request => {
     userService
-      .fetchUserByIdentityId(request.claims.identityId)
+      .fetchUserByOktaId(request.userInfo.oktaId)
       .map(_.map(user => Ok(toJson(user)(writes.me))).getOrElse(NotFound))
-  )
+  })
 }

--- a/app/services/UserService.scala
+++ b/app/services/UserService.scala
@@ -6,5 +6,5 @@ import scala.concurrent.Future
 
 trait UserService extends Service {
 
-  def fetchUserByIdentityId(identityId: String): Future[Option[User]]
+  def fetchUserByOktaId(oktaId: String): Future[Option[User]]
 }

--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,7 @@ lazy val root = (project in file("."))
       ("com.gu" %% "simple-configuration-ssm" % "2.0.0").cross(CrossVersion.for3Use2_13),
       /* Using Scala 2.13 version of identity-auth-play until a Scala 3 version has been released:
        * https://trello.com/c/5kOc41kD/4669-release-scala-3-version-of-identity-libraries */
-      ("com.gu.identity" %% "identity-auth-core" % "4.24")
+      ("com.gu.identity" %% "identity-auth-core" % "4.25")
         .cross(CrossVersion.for3Use2_13)
         exclude ("org.scala-lang.modules", "scala-xml_2.13")
         exclude ("org.scala-lang.modules", "scala-parser-combinators_2.13")

--- a/test/auth/AuthorisedActionSpec.scala
+++ b/test/auth/AuthorisedActionSpec.scala
@@ -61,10 +61,19 @@ class AuthorisedActionSpec extends PlaySpec {
     }
 
     "return 200 when the token is valid and has the required scopes" in {
+      val userInfo = OktaAuthenticatedUserInfo[DefaultIdentityClaims, DefaultAccessClaims](
+        localAccessTokenClaims = DefaultAccessClaims(
+          oktaId = "someOktaId",
+          primaryEmailAddress = "a@b.com",
+          identityId = "I43",
+          username = None
+        ),
+        serverSideUserInfo = None
+      )
       val authService = mock[OktaAuthService]
       when(authService.validateAccessToken(AccessToken("validToken"), requiredScopes))
         .thenReturn(
-          IO.pure(DefaultAccessClaims(primaryEmailAddress = "a@b.com", identityId = "I43", username = None))
+          IO.pure(userInfo)
         )
       val bodyParser = mock[BodyParser[AnyContent]]
       val action = new AuthorisedAction(authService, bodyParser, requiredScopes)


### PR DESCRIPTION

## What does this change?

The current code uses the legacy identity id from the okta access token to find the user in the legacy repository first, and then from the okta id in the retrieved user the actual okta user is fetched.
With this pr we actually fetch the user from the okta id stored in the token first and then we fetch the additional fields from the legacy database.

