### PR TITLE
Provision new Aurora DB cluster for Identity migration

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -15,6 +15,10 @@ new Gatehouse(app, 'gatehouse-CODE', {
 	env,
 	stage: 'CODE',
 	domainName: 'gatehouse-origin.code.dev-guardianapis.com',
+	database: {
+		minCapacity: 0,
+		maxCapacity: 1,
+	},
 });
 
 new Gatehouse(app, 'gatehouse-PROD', {
@@ -22,4 +26,8 @@ new Gatehouse(app, 'gatehouse-PROD', {
 	env,
 	stage: 'PROD',
 	domainName: 'gatehouse-origin.guardianapis.com',
+	database: {
+		minCapacity: 0,
+		maxCapacity: 1,
+	},
 });

--- a/cdk/lib/__snapshots__/gatehouse.test.ts.snap
+++ b/cdk/lib/__snapshots__/gatehouse.test.ts.snap
@@ -289,7 +289,7 @@ exports[`The Gatehouse stack matches the snapshot 1`] = `
         "EnableHttpEndpoint": true,
         "EnableIAMDatabaseAuthentication": true,
         "Engine": "aurora-postgresql",
-        "EngineVersion": "15.10",
+        "EngineVersion": "16.6",
         "ManageMasterUserPassword": true,
         "MasterUsername": "postgres",
         "MonitoringInterval": 60,
@@ -396,8 +396,8 @@ exports[`The Gatehouse stack matches the snapshot 1`] = `
     },
     "GatehouseDbParameterGroupAD12D077": {
       "Properties": {
-        "Description": "Cluster parameter group for aurora-postgresql15",
-        "Family": "aurora-postgresql15",
+        "Description": "Cluster parameter group for aurora-postgresql16",
+        "Family": "aurora-postgresql16",
         "Parameters": {
           "rds.force_ssl": "1",
         },

--- a/cdk/lib/__snapshots__/gatehouse.test.ts.snap
+++ b/cdk/lib/__snapshots__/gatehouse.test.ts.snap
@@ -28,6 +28,7 @@ exports[`The Gatehouse stack matches the snapshot 1`] = `
       "GuApplicationTargetGroup",
       "GuHttpsApplicationListener",
       "GuCname",
+      "GuSubnetListParameter",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -56,6 +57,11 @@ exports[`The Gatehouse stack matches the snapshot 1`] = `
       "Default": "/account/services/logging.stream.name",
       "Description": "SSM parameter containing the Name (not ARN) on the kinesis stream",
       "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+    "PrivateSubnets": {
+      "Default": "/account/vpc/primary/subnets/private",
+      "Description": "A list of private subnets",
+      "Type": "AWS::SSM::Parameter::Value<List<AWS::EC2::Subnet::Id>>",
     },
     "VpcId": {
       "Default": "/account/vpc/primary/id",
@@ -205,6 +211,25 @@ exports[`The Gatehouse stack matches the snapshot 1`] = `
       "Type": "AWS::CertificateManager::Certificate",
       "UpdateReplacePolicy": "Retain",
     },
+    "ClientSecurityGroupOutputParameter16694915": {
+      "Properties": {
+        "Name": "/TEST/identity/gatehouse/db-clients-security-group",
+        "Tags": {
+          "Stack": "identity",
+          "Stage": "TEST",
+          "gu:cdk:version": "TEST",
+          "gu:repo": "guardian/gatehouse",
+        },
+        "Type": "String",
+        "Value": {
+          "Fn::GetAtt": [
+            "RDSSecurityGroupClientsE0F4CB29",
+            "GroupId",
+          ],
+        },
+      },
+      "Type": "AWS::SSM::Parameter",
+    },
     "DescribeEC2PolicyFF5F9295": {
       "Properties": {
         "PolicyDocument": {
@@ -247,6 +272,288 @@ exports[`The Gatehouse stack matches the snapshot 1`] = `
         "TTL": 3600,
       },
       "Type": "Guardian::DNS::RecordSet",
+    },
+    "GatehouseDbFE0B3FEE": {
+      "DeletionPolicy": "Snapshot",
+      "Properties": {
+        "AutoMinorVersionUpgrade": false,
+        "CopyTagsToSnapshot": true,
+        "DBClusterParameterGroupName": {
+          "Ref": "GatehouseDbParameterGroupAD12D077",
+        },
+        "DBSubnetGroupName": {
+          "Ref": "GatehouseDbSubnetsD1F185BF",
+        },
+        "DatabaseName": "gatehouse",
+        "DeletionProtection": true,
+        "EnableHttpEndpoint": true,
+        "EnableIAMDatabaseAuthentication": true,
+        "Engine": "aurora-postgresql",
+        "EngineVersion": "15.10",
+        "ManageMasterUserPassword": true,
+        "MasterUsername": "postgres",
+        "MonitoringInterval": 60,
+        "MonitoringRoleArn": {
+          "Fn::GetAtt": [
+            "GatehouseDbMonitoringRole2A95BC4D",
+            "Arn",
+          ],
+        },
+        "PerformanceInsightsEnabled": true,
+        "PerformanceInsightsRetentionPeriod": 7,
+        "Port": 5432,
+        "ServerlessV2ScalingConfiguration": {
+          "MaxCapacity": 1,
+          "MinCapacity": 0,
+        },
+        "StorageEncrypted": true,
+        "Tags": [
+          {
+            "Key": "devx-backup-enabled",
+            "Value": "true",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/gatehouse",
+          },
+          {
+            "Key": "Stack",
+            "Value": "identity",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "VpcSecurityGroupIds": [
+          {
+            "Fn::GetAtt": [
+              "RDSSecurityGroupRules40FD365B",
+              "GroupId",
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::RDS::DBCluster",
+      "UpdateReplacePolicy": "Snapshot",
+    },
+    "GatehouseDbMonitoringRole2A95BC4D": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "monitoring.rds.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "devx-backup-enabled",
+            "Value": "true",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/gatehouse",
+          },
+          {
+            "Key": "Stack",
+            "Value": "identity",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "GatehouseDbParameterGroupAD12D077": {
+      "Properties": {
+        "Description": "Cluster parameter group for aurora-postgresql15",
+        "Family": "aurora-postgresql15",
+        "Parameters": {
+          "rds.force_ssl": "1",
+        },
+        "Tags": [
+          {
+            "Key": "devx-backup-enabled",
+            "Value": "true",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/gatehouse",
+          },
+          {
+            "Key": "Stack",
+            "Value": "identity",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::RDS::DBClusterParameterGroup",
+    },
+    "GatehouseDbSubnetsD1F185BF": {
+      "Properties": {
+        "DBSubnetGroupDescription": "Subnets for GatehouseDb database",
+        "SubnetIds": [
+          {
+            "Fn::Select": [
+              0,
+              {
+                "Ref": "PrivateSubnets",
+              },
+            ],
+          },
+          {
+            "Fn::Select": [
+              1,
+              {
+                "Ref": "PrivateSubnets",
+              },
+            ],
+          },
+          {
+            "Fn::Select": [
+              2,
+              {
+                "Ref": "PrivateSubnets",
+              },
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "devx-backup-enabled",
+            "Value": "true",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/gatehouse",
+          },
+          {
+            "Key": "Stack",
+            "Value": "identity",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::RDS::DBSubnetGroup",
+    },
+    "GatehouseDbreader63FF6C0B": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "GatehouseDbwriter4093A800",
+      ],
+      "Properties": {
+        "DBClusterIdentifier": {
+          "Ref": "GatehouseDbFE0B3FEE",
+        },
+        "DBInstanceClass": "db.serverless",
+        "Engine": "aurora-postgresql",
+        "PromotionTier": 1,
+        "PubliclyAccessible": false,
+        "Tags": [
+          {
+            "Key": "devx-backup-enabled",
+            "Value": "true",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/gatehouse",
+          },
+          {
+            "Key": "Stack",
+            "Value": "identity",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::RDS::DBInstance",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "GatehouseDbwriter4093A800": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "DBClusterIdentifier": {
+          "Ref": "GatehouseDbFE0B3FEE",
+        },
+        "DBInstanceClass": "db.serverless",
+        "Engine": "aurora-postgresql",
+        "PromotionTier": 0,
+        "PubliclyAccessible": false,
+        "Tags": [
+          {
+            "Key": "devx-backup-enabled",
+            "Value": "true",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/gatehouse",
+          },
+          {
+            "Key": "Stack",
+            "Value": "identity",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::RDS::DBInstance",
+      "UpdateReplacePolicy": "Delete",
     },
     "GetDistributablePolicyGatehouse34FFC5AF": {
       "Properties": {
@@ -661,6 +968,99 @@ exports[`The Gatehouse stack matches the snapshot 1`] = `
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "RDSSecurityGroupClientsE0F4CB29": {
+      "Properties": {
+        "GroupDescription": "Allow access to Gatehouse DB from Clients",
+        "SecurityGroupEgress": [
+          {
+            "CidrIp": "255.255.255.255/32",
+            "Description": "Disallow all traffic",
+            "FromPort": 252,
+            "IpProtocol": "icmp",
+            "ToPort": 86,
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/gatehouse",
+          },
+          {
+            "Key": "Stack",
+            "Value": "identity",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "VpcId": {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "RDSSecurityGroupRules40FD365B": {
+      "Properties": {
+        "GroupDescription": "gatehouse-TEST/RDSSecurityGroupRules",
+        "SecurityGroupEgress": [
+          {
+            "CidrIp": "255.255.255.255/32",
+            "Description": "Disallow all traffic",
+            "FromPort": 252,
+            "IpProtocol": "icmp",
+            "ToPort": 86,
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/gatehouse",
+          },
+          {
+            "Key": "Stack",
+            "Value": "identity",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "VpcId": {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "RDSSecurityGroupRulesfromgatehouseTESTRDSSecurityGroupClientsEA96E72954327FBC3317": {
+      "Properties": {
+        "Description": "from gatehouseTESTRDSSecurityGroupClientsEA96E729:5432",
+        "FromPort": 5432,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "RDSSecurityGroupRules40FD365B",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Fn::GetAtt": [
+            "RDSSecurityGroupClientsE0F4CB29",
+            "GroupId",
+          ],
+        },
+        "ToPort": 5432,
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress",
     },
     "ReadAppSsmParamsPolicy9DC17627": {
       "Properties": {

--- a/cdk/lib/gatehouse.test.ts
+++ b/cdk/lib/gatehouse.test.ts
@@ -9,6 +9,10 @@ describe('The Gatehouse stack', () => {
 			stack: 'identity',
 			stage: 'TEST',
 			domainName: 'id.test.dev-guardianapis.com',
+			database: {
+				minCapacity: 0,
+				maxCapacity: 1,
+			},
 		});
 		const template = Template.fromStack(stack);
 		expect(template.toJSON()).toMatchSnapshot();

--- a/cdk/lib/gatehouse.ts
+++ b/cdk/lib/gatehouse.ts
@@ -266,7 +266,7 @@ export class Gatehouse extends GuStack {
 
 		const cluster = new DatabaseCluster(this, 'GatehouseDb', {
 			engine: DatabaseClusterEngine.auroraPostgres({
-				version: AuroraPostgresEngineVersion.VER_15_10,
+				version: AuroraPostgresEngineVersion.VER_16_6,
 			}),
 			writer: ClusterInstance.serverlessV2('writer'),
 			readers: [

--- a/cdk/lib/gatehouse.ts
+++ b/cdk/lib/gatehouse.ts
@@ -7,20 +7,31 @@ import {
 	GuStringParameter,
 } from '@guardian/cdk/lib/constructs/core';
 import { GuCname } from '@guardian/cdk/lib/constructs/dns';
+import { GuVpc, SubnetType } from '@guardian/cdk/lib/constructs/ec2';
 import {
 	GuPolicy,
 	ReadParametersByName,
 } from '@guardian/cdk/lib/constructs/iam';
 import type { App } from 'aws-cdk-lib';
-import { Duration } from 'aws-cdk-lib';
+import { Duration, SecretValue, Tags } from 'aws-cdk-lib';
 import {
 	InstanceClass,
 	InstanceSize,
 	InstanceType,
+	Port,
 	SecurityGroup,
 	UserData,
 } from 'aws-cdk-lib/aws-ec2';
 import { Effect, PolicyStatement } from 'aws-cdk-lib/aws-iam';
+import type { CfnDBCluster } from 'aws-cdk-lib/aws-rds';
+import {
+	AuroraPostgresEngineVersion,
+	ClusterInstance,
+	Credentials,
+	DatabaseCluster,
+	DatabaseClusterEngine,
+	PerformanceInsightRetention,
+} from 'aws-cdk-lib/aws-rds';
 import {
 	ParameterDataType,
 	ParameterTier,
@@ -29,21 +40,35 @@ import {
 
 export interface GatehouseStackProps extends GuStackProps {
 	domainName: string;
+	database: {
+		minCapacity: number;
+		maxCapacity: number;
+	};
 }
 
 export class Gatehouse extends GuStack {
 	constructor(scope: App, id: string, props: GatehouseStackProps) {
 		super(scope, id, props);
 
+		const {
+			stack,
+			stage,
+			database: {
+				minCapacity: serverlessV2MinCapacity,
+				maxCapacity: serverlessV2MaxCapacity,
+			},
+		} = props;
+
 		const ec2App = 'gatehouse';
+		const databasePort = 5432;
 
 		const distBucket =
 			GuDistributionBucketParameter.getInstance(this).valueAsString;
 
 		const artifactPath = [
 			distBucket,
-			this.stack,
-			this.stage,
+			stack,
+			stage,
 			ec2App,
 			`${ec2App}.deb`,
 		].join('/');
@@ -84,7 +109,7 @@ export class Gatehouse extends GuStack {
 			'rdsSecurityGroupId',
 			{
 				fromSSM: true,
-				default: `/${this.stage}/${this.stack}/${ec2App}/rdsSecurityGroup/id`,
+				default: `/${stage}/${stack}/${ec2App}/rdsSecurityGroup/id`,
 				description: 'ID of database security group.',
 			},
 		);
@@ -199,8 +224,8 @@ export class Gatehouse extends GuStack {
 
 		// This parameter is used by https://github.com/guardian/waf
 		new StringParameter(this, 'AlbSsmParam', {
-			parameterName: `/infosec/waf/services/${this.stage}/gatehouse-alb-arn`,
-			description: `The ARN of the ALB for identity-${this.stage}-gatehouse. N.B. This parameter is created via CDK.`,
+			parameterName: `/infosec/waf/services/${stage}/gatehouse-alb-arn`,
+			description: `The ARN of the ALB for identity-${stage}-gatehouse. N.B. This parameter is created via CDK.`,
 			simpleName: false,
 			stringValue: app.loadBalancer.loadBalancerArn,
 			tier: ParameterTier.STANDARD,
@@ -212,6 +237,94 @@ export class Gatehouse extends GuStack {
 			ttl: Duration.hours(1),
 			domainName: props.domainName,
 			resourceRecord: app.loadBalancer.loadBalancerDnsName,
+		});
+
+		const vpc = GuVpc.fromIdParameter(this, 'IdentityVPC');
+		const rdsSecurityGroupRules = new SecurityGroup(
+			this,
+			'RDSSecurityGroupRules',
+			{
+				vpc: vpc,
+				allowAllOutbound: false,
+			},
+		);
+
+		const rdsSecurityGroupClients = new SecurityGroup(
+			this,
+			'RDSSecurityGroupClients',
+			{
+				vpc: vpc,
+				allowAllOutbound: false,
+				description: 'Allow access to Gatehouse DB from Clients',
+			},
+		);
+
+		rdsSecurityGroupRules.addIngressRule(
+			rdsSecurityGroupClients,
+			Port.tcp(databasePort),
+		);
+
+		const cluster = new DatabaseCluster(this, 'GatehouseDb', {
+			engine: DatabaseClusterEngine.auroraPostgres({
+				version: AuroraPostgresEngineVersion.VER_15_10,
+			}),
+			writer: ClusterInstance.serverlessV2('writer'),
+			readers: [
+				// Scale reader instance with writer so that it can deal with immediate traffic spike during failover
+				ClusterInstance.serverlessV2('reader', { scaleWithWriter: true }),
+			],
+			credentials: Credentials.fromPassword(
+				'postgres',
+				// This value will be replaced by the escape hatch to use ManagerMasterUserPassword below
+				SecretValue.secretsManager('uselessWorkaroundSecret'),
+			),
+			storageEncrypted: true,
+			deletionProtection: true,
+			iamAuthentication: true,
+			enableDataApi: true,
+			enableClusterLevelEnhancedMonitoring: true,
+			enablePerformanceInsights: true,
+			// Under some scenarios AWS can upgrade the database version without downtime
+			// However all upgrades, including minor ones, can result in downtime in certain scenarios.
+			// https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/USER_UpgradeDBInstance.PostgreSQL.MinorUpgrade.html
+			autoMinorVersionUpgrade: false,
+			performanceInsightRetention: PerformanceInsightRetention.DEFAULT,
+			monitoringInterval: Duration.minutes(1),
+			defaultDatabaseName: 'gatehouse',
+			port: databasePort,
+			serverlessV2MinCapacity,
+			serverlessV2MaxCapacity,
+			securityGroups: [rdsSecurityGroupRules],
+			vpcSubnets: {
+				subnets: GuVpc.subnetsFromParameterFixedNumber(
+					this,
+					{
+						type: SubnetType.PRIVATE,
+					},
+					3,
+				),
+			},
+			vpc,
+			parameters: {
+				// Require verifying SSL before connecting to DB
+				'rds.force_ssl': '1',
+			},
+		});
+
+		// Resources tagged with devx-backup-enabled=true will be backed up by the DevX backup service
+		// https://github.com/guardian/aws-account-setup/blob/42885f5d22dbee137950d4e7500bbb1d7cc1bf77/packages/cdk/lib/aws-backup.ts#L72-L76
+		Tags.of(cluster).add('devx-backup-enabled', 'true');
+
+		// CDK currently does not support ManagerMasterUserPassword
+		// See https://github.com/aws/aws-cdk/issues/29239
+		const defaultChild = cluster.node.defaultChild as CfnDBCluster;
+		defaultChild.addOverride('Properties.ManageMasterUserPassword', true);
+		defaultChild.addOverride('Properties.MasterUserPassword', undefined);
+
+		// Output RDS Client security group as SSM parameter to be used in other stacks.
+		new StringParameter(this, 'ClientSecurityGroupOutputParameter', {
+			parameterName: `/${stage}/${stack}/${ec2App}/db-clients-security-group`,
+			stringValue: rdsSecurityGroupClients.securityGroupId,
 		});
 	}
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Provisions a new Aurora database cluster for the Identity DB migration work.

Listed below are some of the RDS features that have been enabled/disabled:

- **Enable Deletion Protection**

  Prevents the database from being deleted by accident. Can be turned off if required after creation.

- **Turn on Force SSL**

  Require clients to use SSL when connecting to the database, this prevents data from being sent over an insecure connection and requires that clients verify that they are connecting to the correct database.

- **Turn on Performance Insights**

  Collects performance information from the database about what queries are being ran, what users are connected, and how much load they're causing to the database. Retention has been left on default AWS free tier which is 7 days.

- **Turn on Enhanced Monitoring**

  Collect Cloudwatch metrics about the OS that the database is running on such as memory usage, detailed CPU usage, and active processes.

- **Provision an additional reader instance**

  Aurora requires atleast 2 instances in order to be multi AZ. Should the primary writer instance fail Aurora will automatically promote the reader instance to be the primary writer instance.

- **Switch off Minor Version Upgrades**

  Aurora supports ZDP (Zero Downtime Patching) but it only works on a best-effort basis and doesn't gurantee zero downtime https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/USER_UpgradeDBInstance.PostgreSQL.MinorUpgrade.html#USER_UpgradeDBInstance.PostgreSQL.Minor.zdp
  
  In particular it doesn't support TLS 1.3 connections which we'd likely want to be using.
  
  Downtime should only last a few minutes, As part of our migration we should probably come to an agreement with SLT about a time of day where we're allowed to patch our database even if it may cause some downtime.

- **Enable DevX Backups**
  
  Allow DevX to manage backups of our database.


## How to test

Deployed to CODE.
