### PR TITLE
Include setup-scala step in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,12 +28,8 @@ jobs:
           cache: yarn
           cache-dependency-path: cdk/yarn.lock
 
-      # Java is needed for the Scala Play app
-      - uses: actions/setup-java@v4
-        with:
-          java-version: 21
-          distribution: corretto
-          cache: sbt
+      # SBT is needed for the Scala Play app
+      - uses: guardian/setup-scala@v1
 
       # Build CDK and Play (in sequence)
       - run: scripts/ci

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+java corretto-21.0.5.11.1


### PR DESCRIPTION
This replaces the setup-java step with setup-scala now that SBT has to be installed as well.

Setting Java version to latest Corretto LTS release.