### PR TITLE
Save Gatehouse DB identifier as SSM parameter

### DIFF
--- a/cdk/lib/__snapshots__/gatehouse.test.ts.snap
+++ b/cdk/lib/__snapshots__/gatehouse.test.ts.snap
@@ -230,6 +230,22 @@ exports[`The Gatehouse stack matches the snapshot 1`] = `
       },
       "Type": "AWS::SSM::Parameter",
     },
+    "DatabaseClusterIdentifierOutputParameterC8ADF3BB": {
+      "Properties": {
+        "Name": "/TEST/identity/gatehouse/db-identifier",
+        "Tags": {
+          "Stack": "identity",
+          "Stage": "TEST",
+          "gu:cdk:version": "TEST",
+          "gu:repo": "guardian/gatehouse",
+        },
+        "Type": "String",
+        "Value": {
+          "Ref": "GatehouseDbFE0B3FEE",
+        },
+      },
+      "Type": "AWS::SSM::Parameter",
+    },
     "DescribeEC2PolicyFF5F9295": {
       "Properties": {
         "PolicyDocument": {

--- a/cdk/lib/gatehouse.ts
+++ b/cdk/lib/gatehouse.ts
@@ -331,5 +331,11 @@ export class Gatehouse extends GuStack {
 			parameterName: `/${stage}/${stack}/${ec2App}/db-clients-security-group`,
 			stringValue: rdsSecurityGroupClients.securityGroupId,
 		});
+
+		// Output DB Identifier as SSM parameter to be used in other stacks.
+		new StringParameter(this, 'DatabaseClusterIdentifierOutputParameter', {
+			parameterName: `/${stage}/${stack}/${ec2App}/db-identifier`,
+			stringValue: cluster.clusterIdentifier,
+		});
 	}
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Output the Gatehouse DB identifier as an SSM parameter so that other stacks can create policies that reference it, for example: https://github.com/guardian/identity/pull/2668

## How to test

Deploy to CODE, check correct value is in SSM.
