### PR TITLE
Output clusterResourceIdentifier from Gatehouse CDK

### DIFF
--- a/cdk/lib/__snapshots__/gatehouse.test.ts.snap
+++ b/cdk/lib/__snapshots__/gatehouse.test.ts.snap
@@ -246,6 +246,25 @@ exports[`The Gatehouse stack matches the snapshot 1`] = `
       },
       "Type": "AWS::SSM::Parameter",
     },
+    "DatabaseClusterResourceIdentifierOutputParameterB1B033B2": {
+      "Properties": {
+        "Name": "/TEST/identity/gatehouse/db-resource-identifier",
+        "Tags": {
+          "Stack": "identity",
+          "Stage": "TEST",
+          "gu:cdk:version": "TEST",
+          "gu:repo": "guardian/gatehouse",
+        },
+        "Type": "String",
+        "Value": {
+          "Fn::GetAtt": [
+            "GatehouseDbFE0B3FEE",
+            "DBClusterResourceId",
+          ],
+        },
+      },
+      "Type": "AWS::SSM::Parameter",
+    },
     "DescribeEC2PolicyFF5F9295": {
       "Properties": {
         "PolicyDocument": {

--- a/cdk/lib/gatehouse.ts
+++ b/cdk/lib/gatehouse.ts
@@ -337,5 +337,14 @@ export class Gatehouse extends GuStack {
 			parameterName: `/${stage}/${stack}/${ec2App}/db-identifier`,
 			stringValue: cluster.clusterIdentifier,
 		});
+
+		new StringParameter(
+			this,
+			'DatabaseClusterResourceIdentifierOutputParameter',
+			{
+				parameterName: `/${stage}/${stack}/${ec2App}/db-resource-identifier`,
+				stringValue: cluster.clusterResourceIdentifier,
+			},
+		);
 	}
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

We previously exported the `clusterIdentifier` for the new Gatehouse DB in https://github.com/guardian/gatehouse/pull/106 , as it turns out from testing on Identity what we actually need to setup an IAM policy is the `clusterResourceIdentifier` instead.

We still need the `clusterIdentifier` for the migrate script, so keep it around for now.

## How to test

Deploy this gatehouse branch to code, and then deploy https://github.com/guardian/identity/pull/2666 to CODE.
