### PR TITLE
Scale up PROD Gatehouse DB

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -27,7 +27,7 @@ new Gatehouse(app, 'gatehouse-PROD', {
 	stage: 'PROD',
 	domainName: 'gatehouse-origin.guardianapis.com',
 	database: {
-		minCapacity: 0,
-		maxCapacity: 1,
+		minCapacity: 1,
+		maxCapacity: 8,
 	},
 });


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

In preparation of https://github.com/guardian/identity/pull/2666 scale up the PROD Gatehouse maximum and minimum capacities.

In theory we shouldn't need that much capacity as all that will be running is `SELECT 1` queries from the Healthcheck, but lets scale up just in case and then tinker with the scale afterwards once we get an understanding of how many resources PROD is using
