### PR TITLE
Increase CODE DB minimum capacity to 0.5

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -16,7 +16,7 @@ new Gatehouse(app, 'gatehouse-CODE', {
 	stage: 'CODE',
 	domainName: 'gatehouse-origin.code.dev-guardianapis.com',
 	database: {
-		minCapacity: 0,
+		minCapacity: 0.5,
 		maxCapacity: 1,
 	},
 });


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Increase the minimum capacity of the CODE DB cluster to 0.5

Identity API has a weird issue where if it fails to connect to the DB during startup it will crash and not restart for ~15-30 minutes.

If the Aurora cluster is at 0 capacity it takes half a minute for the cluster to start which is enough time for Identity API to crash, resulting in a deathloop as Identity API doesn't retry the connection till it reboots 15-30 minutes later at which point Aurora has decided to go back to sleep due to the lack of connections.

Realistically we'd never be able to take advantage of 0 capacity anyway as there will almost always be Identity API with open connections in CODE due to connection pooling.
