### PR TITLE
feat: Add new Gatehouse DB user for `identity_okta_tools`

### DIFF
--- a/db/migrations/V202502251527__identity_okta_tools_user.sql
+++ b/db/migrations/V202502251527__identity_okta_tools_user.sql
@@ -1,0 +1,13 @@
+CREATE USER identity_okta_tools;
+GRANT SELECT ON users TO identity_okta_tools;
+
+-- Run inside an anonymous function in order to use conditional logic such as IF
+DO
+$do$
+    BEGIN
+        -- The rds_iam role is created by the RDS IAM extension, which is not available in DEV
+        IF EXISTS (select * from pg_roles where rolname='rds_iam') THEN
+            GRANT rds_iam TO identity_okta_tools;
+        END IF;
+    END
+$do$;


### PR DESCRIPTION
## What does this change?

Adds a new user to allow the `identity-okta-tools` app to access Gatehouse to get data for the Data Lake export.

## How to test

Deploy to CODE and use a tool such as IntelliJ to login to the DB using IAM credentials.
