### PR TITLE
feat: Use DMS to migrate data from legacy identity DB to Gatehouse

### DIFF
--- a/cdk/lib/__snapshots__/gatehouse.test.ts.snap
+++ b/cdk/lib/__snapshots__/gatehouse.test.ts.snap
@@ -29,6 +29,8 @@ exports[`The Gatehouse stack matches the snapshot 1`] = `
       "GuHttpsApplicationListener",
       "GuCname",
       "GuSubnetListParameter",
+      "GuRole",
+      "GuRole",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -229,6 +231,445 @@ exports[`The Gatehouse stack matches the snapshot 1`] = `
         },
       },
       "Type": "AWS::SSM::Parameter",
+    },
+    "DMSGatehouseTargetEndpoint": {
+      "Properties": {
+        "DatabaseName": "gatehouse",
+        "EndpointType": "target",
+        "EngineName": "postgres",
+        "PostgreSqlSettings": {
+          "SecretsManagerAccessRoleArn": {
+            "Fn::GetAtt": [
+              "DMSTargetIamRole66589FB2",
+              "Arn",
+            ],
+          },
+          "SecretsManagerSecretId": {
+            "Ref": "DMSTargetCredentials69E635CE",
+          },
+        },
+        "SslMode": "require",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/gatehouse",
+          },
+          {
+            "Key": "Stack",
+            "Value": "identity",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::DMS::Endpoint",
+    },
+    "DMSIdentitySourceEndpoint": {
+      "Properties": {
+        "DatabaseName": "identitydb",
+        "EndpointType": "source",
+        "EngineName": "postgres",
+        "PostgreSqlSettings": {
+          "SecretsManagerAccessRoleArn": {
+            "Fn::GetAtt": [
+              "DMSSourceIamRole0E67A5F6",
+              "Arn",
+            ],
+          },
+          "SecretsManagerSecretId": {
+            "Ref": "DMSSourceCredentials751FB3FA",
+          },
+        },
+        "SslMode": "require",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/gatehouse",
+          },
+          {
+            "Key": "Stack",
+            "Value": "identity",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::DMS::Endpoint",
+    },
+    "DMSReplicationConfig": {
+      "Properties": {
+        "ComputeConfig": {
+          "MaxCapacityUnits": 16,
+          "MinCapacityUnits": 1,
+          "ReplicationSubnetGroupId": {
+            "Ref": "DMSReplicationSubnetGroup",
+          },
+          "VpcSecurityGroupIds": [
+            {
+              "Fn::GetAtt": [
+                "RDSSecurityGroupClientsE0F4CB29",
+                "GroupId",
+              ],
+            },
+            {
+              "Ref": "rdsSecurityGroupId",
+            },
+          ],
+        },
+        "ReplicationConfigIdentifier": "gatehouse-TEST",
+        "ReplicationSettings": {
+          "Logging": {
+            "EnableLogging": true,
+          },
+        },
+        "ReplicationType": "full-load",
+        "SourceEndpointArn": {
+          "Ref": "DMSIdentitySourceEndpoint",
+        },
+        "TableMappings": {
+          "rules": [
+            {
+              "filters": [],
+              "object-locator": {
+                "schema-name": "public",
+                "table-name": "users",
+              },
+              "rule-action": "include",
+              "rule-id": "1",
+              "rule-name": "1",
+              "rule-type": "selection",
+            },
+            {
+              "object-locator": {
+                "schema-name": "public",
+                "table-name": "users",
+              },
+              "rule-action": "add-prefix",
+              "rule-id": "2",
+              "rule-name": "2",
+              "rule-target": "table",
+              "rule-type": "transformation",
+              "value": "identity_",
+            },
+          ],
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/gatehouse",
+          },
+          {
+            "Key": "Stack",
+            "Value": "identity",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "TargetEndpointArn": {
+          "Ref": "DMSGatehouseTargetEndpoint",
+        },
+      },
+      "Type": "AWS::DMS::ReplicationConfig",
+    },
+    "DMSReplicationSubnetGroup": {
+      "Properties": {
+        "ReplicationSubnetGroupDescription": "DMS Replication Subnet Group",
+        "SubnetIds": [
+          {
+            "Fn::Select": [
+              0,
+              {
+                "Ref": "PrivateSubnets",
+              },
+            ],
+          },
+          {
+            "Fn::Select": [
+              1,
+              {
+                "Ref": "PrivateSubnets",
+              },
+            ],
+          },
+          {
+            "Fn::Select": [
+              2,
+              {
+                "Ref": "PrivateSubnets",
+              },
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/gatehouse",
+          },
+          {
+            "Key": "Stack",
+            "Value": "identity",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::DMS::ReplicationSubnetGroup",
+    },
+    "DMSSourceCredentials751FB3FA": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "GenerateSecretString": {},
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/gatehouse",
+          },
+          {
+            "Key": "Stack",
+            "Value": "identity",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::SecretsManager::Secret",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "DMSSourceIamRole0E67A5F6": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Condition": {
+                "StringEquals": {
+                  "aws:SourceAccount": {
+                    "Ref": "AWS::AccountId",
+                  },
+                },
+              },
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "dms.amazonaws.com",
+              },
+            },
+            {
+              "Action": "sts:AssumeRole",
+              "Condition": {
+                "StringEquals": {
+                  "aws:SourceAccount": {
+                    "Ref": "AWS::AccountId",
+                  },
+                },
+              },
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "dms.eu-west-1.amazonaws.com",
+              },
+            },
+            {
+              "Action": "sts:AssumeRole",
+              "Condition": {
+                "StringEquals": {
+                  "aws:SourceAccount": {
+                    "Ref": "AWS::AccountId",
+                  },
+                },
+              },
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "dms-data-migrations.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "secretsmanager:DescribeSecret",
+                    "secretsmanager:GetSecretValue",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Ref": "DMSSourceCredentials751FB3FA",
+                  },
+                },
+              ],
+              "Version": "2012-10-17",
+            },
+            "PolicyName": "retrieveCredentials",
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/gatehouse",
+          },
+          {
+            "Key": "Stack",
+            "Value": "identity",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "DMSTargetCredentials69E635CE": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "GenerateSecretString": {},
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/gatehouse",
+          },
+          {
+            "Key": "Stack",
+            "Value": "identity",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::SecretsManager::Secret",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "DMSTargetIamRole66589FB2": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Condition": {
+                "StringEquals": {
+                  "aws:SourceAccount": {
+                    "Ref": "AWS::AccountId",
+                  },
+                },
+              },
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "dms.amazonaws.com",
+              },
+            },
+            {
+              "Action": "sts:AssumeRole",
+              "Condition": {
+                "StringEquals": {
+                  "aws:SourceAccount": {
+                    "Ref": "AWS::AccountId",
+                  },
+                },
+              },
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "dms.eu-west-1.amazonaws.com",
+              },
+            },
+            {
+              "Action": "sts:AssumeRole",
+              "Condition": {
+                "StringEquals": {
+                  "aws:SourceAccount": {
+                    "Ref": "AWS::AccountId",
+                  },
+                },
+              },
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "dms-data-migrations.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "secretsmanager:DescribeSecret",
+                    "secretsmanager:GetSecretValue",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Ref": "DMSTargetCredentials69E635CE",
+                  },
+                },
+              ],
+              "Version": "2012-10-17",
+            },
+            "PolicyName": "retrieveCredentials",
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/gatehouse",
+          },
+          {
+            "Key": "Stack",
+            "Value": "identity",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
     },
     "DatabaseClusterIdentifierOutputParameterC8ADF3BB": {
       "Properties": {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Provision a Serverless DMS Migration to migrate the entire `users` table from the Identity DB to the Gatehouse DB.

### Create Source User

Create a user in Identity DB with read access to users table for the purpose of running the migration.

```sql
CREATE USER gatehouse_migration WITH PASSWORD 'randomly generated password';
GRANT rds_replication ON gatehouse_migration;

GRANT USAGE ON SCHEMA public;
GRANT SELECT ON TABLE users;
```

Save the credentials for this user in the newly created secrets manager secret in the format: 

```json
{
    "username": "username",
    "password": "password",
    "port": 5432,
    "host": "Identity DB RDS Hostname"
}
```

### Create Target User

The target user needs to have superadmin in order to be able to create the required tables. For the purposes of this migration we can just use our default superadmin user which the credentials for can be found in Secrets Manager.

These credentials need to then be saved to the newly created secret in the same format as the Source user.

### Run the Migration

Head to [DMS Serverless Replications](https://eu-west-1.console.aws.amazon.com/dms/v2/home?region=eu-west-1#replications) in the AWS Console, find the appropriate migration and click "Start"

<img width="169" alt="image" src="https://github.com/user-attachments/assets/963b040c-76c5-45e8-bfe2-8f54d62cc798" />

This will kick off the migration and copy the table over. This will take a while.

### Delete deleted users

Whilst the migration was happening some users may have been deleted. Delete these users from the staging table with the following query:

```sql
DELETE FROM identity_users WHERE okta_id IN (
   id1,
   id2,
   id3
)
```

A list of deleted user IDs can be found in the Okta logs.

### Copy data to new users table

After migrating the table the following query can be used to copy the data to the new users table:

```sql
INSERT INTO users (id, okta_id, username, braze_uuid, private_uuid, last_activity, retain_until)
SELECT
    id,
    okta_id,
    jdoc->'publicFields'->>'username'::text,
    braze_uuid,
    private_uuid,
    TO_TIMESTAMP(jdoc->'dates'->>'lastActivityDate', 'YYYY-MM-DD\THH24:MI:SSZ'),
    TO_TIMESTAMP(jdoc->'dates'->>'retainUntil', 'YYYY-MM-DD\THH24:MI:SSZ')
FROM identity_users
WHERE okta_id IS NOT NULL
ON CONFLICT DO NOTHING;
```

At this point next time the datalake export runs we should see that all Gatehouse users match Identity.

### Help the migration is starving Identity DB of resources!

```sql
-- Prevent new connections being established.
REVOKE CONNECT ON DATABASE identitydb FROM gatehouse_migration;
-- Terminate existing connections
SELECT *, pg_terminate_backend(pid)
FROM pg_stat_activity
WHERE usename = 'gatehouse_migration';
```

## How to test

Tested in CODE