### PR TITLE
Legacy DB Migration | Store Client credentials in Gatehouse DB

### DIFF
--- a/db/docker-compose.yaml
+++ b/db/docker-compose.yaml
@@ -22,3 +22,5 @@ services:
       "-password=gatehouse",
       "-locations=filesystem:./migrations"
     ]
+    environment:
+      JAVA_ARGS: -XX:UseSVE=0 -XX:+IgnoreUnrecognizedVMOptions

--- a/db/migrations/V202503141216__identity_admin_api_user.sql
+++ b/db/migrations/V202503141216__identity_admin_api_user.sql
@@ -1,0 +1,12 @@
+CREATE USER identity_admin_api;
+
+-- Run inside an anonymous function in order to use conditional logic such as IF
+DO
+$do$
+    BEGIN
+        -- The rds_iam role is created by the RDS IAM extension, which is not available in DEV
+        IF EXISTS (select * from pg_roles where rolname='rds_iam') THEN
+            GRANT rds_iam TO identity_admin_api;
+        END IF;
+    END
+$do$;

--- a/db/migrations/V202503141217__client_access_tokens.sql
+++ b/db/migrations/V202503141217__client_access_tokens.sql
@@ -1,0 +1,22 @@
+CREATE TABLE clients 
+(
+    id TEXT PRIMARY KEY NOT NULL,
+    scopes TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+    created TIMESTAMP DEFAULT now() NOT NULL,
+    updated TIMESTAMP DEFAULT now() NOT NULL
+);
+
+CREATE TABLE client_access_tokens
+(
+    token TEXT NOT NULL PRIMARY KEY,
+    client_id TEXT NOT NULL REFERENCES clients,
+    created TIMESTAMP DEFAULT now() NOT NULL,
+    expiry TIMESTAMP NOT NULL,
+    active BOOLEAN DEFAULT true NOT NULL
+);
+
+GRANT SELECT ON clients TO identity_api;
+GRANT SELECT ON client_access_tokens TO identity_api;
+
+GRANT INSERT, SELECT, UPDATE, DELETE ON clients TO identity_admin_api;
+GRANT INSERT, SELECT, UPDATE, DELETE ON client_access_tokens TO identity_admin_api;


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Add 2 new migrations:
 - Create a **identity_admin_api** user with IAM login credentials to allow Identity Admin API to connect to Gatehoues
 - Create a `clients` and `client_access_tokens` table which mimics the existing `clients` and `clientsaccesstokens` table in Identity DB.

## How to test?

Run `./db/test.sh`