### PR TITLE
Add `registrationLocationState` field

### DIFF
--- a/app/model/User.scala
+++ b/app/model/User.scala
@@ -14,6 +14,7 @@ case class User(
     address: Address,
     phoneNumber: Option[PhoneNumber],
     registrationLocation: Option[String],
+    registrationLocationState: Option[String],
     permissions: Seq[Permission]
 )
 
@@ -30,6 +31,7 @@ object User {
       address = Address.fromOktaUser(oktaUser),
       phoneNumber = PhoneNumber.fromOktaUser(oktaUser),
       registrationLocation = customProfileField(oktaUser, "registrationLocation"),
+      registrationLocationState = customProfileField(oktaUser, "registrationLocationState"),
       permissions = Nil
     )
   }
@@ -63,6 +65,7 @@ object User {
         "internationalDiallingCode" -> user.phoneNumber.map(_.countryCode),
         "localNumber" -> user.phoneNumber.map(_.localNumber),
         "registrationLocation" -> user.registrationLocation,
+        "registrationLocationState" -> user.registrationLocationState,
         "permissions" -> user.permissions
       )
   }

--- a/test/model/UserSpec.scala
+++ b/test/model/UserSpec.scala
@@ -30,6 +30,7 @@ class UserSpec extends PlaySpec with MockitoSugar {
         ),
         phoneNumber = Some(PhoneNumber(44, "12345")),
         registrationLocation = Some("online"),
+        registrationLocationState = Some("other"),
         permissions = Seq(Permission("p1", true), Permission("p2", false), Permission("p3", true))
       )
       Json.stringify(Json.toJson(user)(User.writes.me)) shouldBe
@@ -50,6 +51,7 @@ class UserSpec extends PlaySpec with MockitoSugar {
           |"internationalDiallingCode":44,
           |"localNumber":"12345",
           |"registrationLocation":"online",
+          |"registrationLocationState":"other",
           |"permissions":[{"id":"p1","permitted":true},{"id":"p2","permitted":false},{"id":"p3","permitted":true}]
           |}""".stripMargin.replace("\n", "")
     }

--- a/test/services/OktaUserServiceSpec.scala
+++ b/test/services/OktaUserServiceSpec.scala
@@ -44,6 +44,7 @@ class OktaUserServiceSpec extends PlaySpec with MockitoSugar {
         address = Address(None, None, None, None, None, None),
         phoneNumber = None,
         registrationLocation = None,
+        registrationLocationState = None,
         permissions = Nil
       )
 


### PR DESCRIPTION
## What does this change?

Adds `registrationLocationState` as a user profile field, stored in Okta, and be able to persist it through Gatehouse

## Context

Guardian readers in Australia and the United States are bound by and impacted by state specific regulations and laws. Without this information we are unable to send state specific service emails, editorial newsletters, or marketing emails. In addition, adding state location can inform personalised advertising and partner emails, making advertising more relevant and making partner emails a more relevant perk for our readers.

https://trello.com/c/Hn2lBRSK/1445-scoping-add-state-location-data-point

## Related PRs

- Identity Platform - Okta: https://github.com/guardian/identity-platform/pull/803
- Identity Platform - Fastly: https://github.com/guardian/identity-platform/pull/804
- Identity API: https://github.com/guardian/identity/pull/2697
- Gatehouse (This PR): https://github.com/guardian/gatehouse/pull/133