### PR TITLE
Increase prod db max capacity and add high usage alert

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -28,6 +28,6 @@ new Gatehouse(app, 'gatehouse-PROD', {
 	domainName: 'gatehouse-origin.guardianapis.com',
 	database: {
 		minCapacity: 1,
-		maxCapacity: 8,
+		maxCapacity: 16,
 	},
 });

--- a/cdk/lib/__snapshots__/gatehouse.test.ts.snap
+++ b/cdk/lib/__snapshots__/gatehouse.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`The Gatehouse stack matches the snapshot 1`] = `
 {
@@ -28,6 +28,8 @@ exports[`The Gatehouse stack matches the snapshot 1`] = `
       "GuHttpsApplicationListener",
       "GuCname",
       "GuSubnetListParameter",
+      "GuStringParameter",
+      "GuAlarm",
       "GuRole",
       "GuRole",
     ],
@@ -68,6 +70,11 @@ exports[`The Gatehouse stack matches the snapshot 1`] = `
       "Default": "/account/vpc/primary/id",
       "Description": "Virtual Private Cloud to run EC2 instances within. Should NOT be the account default VPC.",
       "Type": "AWS::SSM::Parameter::Value<AWS::EC2::VPC::Id>",
+    },
+    "alarmNotificationEmail": {
+      "Default": "/TEST/identity/gatehouse/alarmNotificationEmail",
+      "Description": "Notification email for gatehouse DB Alarms.",
+      "Type": "AWS::SSM::Parameter::Value<String>",
     },
     "gatehousePrivateSubnets": {
       "Default": "/account/vpc/primary/subnets/private",
@@ -1190,6 +1197,71 @@ exports[`The Gatehouse stack matches the snapshot 1`] = `
       },
       "Type": "AWS::IAM::Policy",
     },
+    "HighUsageAlarm983B2726": {
+      "Properties": {
+        "ActionsEnabled": false,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":",
+                {
+                  "Fn::GetAtt": [
+                    "NotificationTopicEB7A0DF1",
+                    "TopicName",
+                  ],
+                },
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "Gatehouse usage is above 80%",
+        "AlarmName": "High usage in Gatehouse database",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "Dimensions": [
+          {
+            "Name": "DBClusterIdentifier",
+            "Value": {
+              "Ref": "GatehouseDbFE0B3FEE",
+            },
+          },
+        ],
+        "EvaluationPeriods": 2,
+        "MetricName": "ACUUtilization",
+        "Namespace": "AWS/RDS",
+        "Period": 60,
+        "Statistic": "Average",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/gatehouse",
+          },
+          {
+            "Key": "Stack",
+            "Value": "identity",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "Threshold": 80,
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
     "InstanceRoleGatehouse075DE24E": {
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -1388,6 +1460,42 @@ exports[`The Gatehouse stack matches the snapshot 1`] = `
         "ToPort": 9000,
       },
       "Type": "AWS::EC2::SecurityGroupEgress",
+    },
+    "NotificationTopicEB7A0DF1": {
+      "Properties": {
+        "DisplayName": "Gatehouse notifications",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/gatehouse",
+          },
+          {
+            "Key": "Stack",
+            "Value": "identity",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::SNS::Topic",
+    },
+    "NotificationTopicTokenSubscription180FA58AD": {
+      "Properties": {
+        "Endpoint": {
+          "Ref": "alarmNotificationEmail",
+        },
+        "Protocol": "email",
+        "TopicArn": {
+          "Ref": "NotificationTopicEB7A0DF1",
+        },
+      },
+      "Type": "AWS::SNS::Subscription",
     },
     "ParameterStoreReadGatehouseF4274D8F": {
       "Properties": {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Increase the max capacity for the prod db in preparation for switching to reading from it in PROD. 
We can decrease later if it makes sense with the real production load

