### PR TITLE
fix alarm & roll back capacity change

### DIFF
--- a/cdk/lib/__snapshots__/gatehouse.test.ts.snap
+++ b/cdk/lib/__snapshots__/gatehouse.test.ts.snap
@@ -317,7 +317,7 @@ exports[`The Gatehouse stack matches the snapshot 1`] = `
     "DMSReplicationConfig": {
       "Properties": {
         "ComputeConfig": {
-          "MaxCapacityUnits": 16,
+          "MaxCapacityUnits": 8,
           "MinCapacityUnits": 1,
           "ReplicationSubnetGroupId": {
             "Ref": "DMSReplicationSubnetGroup",
@@ -1225,7 +1225,7 @@ exports[`The Gatehouse stack matches the snapshot 1`] = `
           },
         ],
         "AlarmDescription": "Gatehouse usage is above 80%",
-        "AlarmName": "High usage in Gatehouse database",
+        "AlarmName": "High usage in TEST Gatehouse database",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
         "Dimensions": [
           {

--- a/cdk/lib/gatehouse.ts
+++ b/cdk/lib/gatehouse.ts
@@ -355,7 +355,7 @@ export class Gatehouse extends GuStack {
 		);
 		new GuAlarm(this, 'HighUsageAlarm', {
 			app: 'gatehouseDB',
-			alarmName: 'High usage in Gatehouse database',
+			alarmName: `High usage in ${this.stage} Gatehouse database`,
 			alarmDescription: 'Gatehouse usage is above 80%',
 			snsTopicName: notificationTopic.topicName,
 			actionsEnabled: this.stage === 'PROD',
@@ -535,7 +535,7 @@ export class Gatehouse extends GuStack {
 			},
 			computeConfig: {
 				minCapacityUnits: 1,
-				maxCapacityUnits: 16,
+				maxCapacityUnits: 8,
 				replicationSubnetGroupId: dmsSubnetGroup.ref,
 				vpcSecurityGroupIds: [
 					rdsSecurityGroupClients.securityGroupId,


### PR DESCRIPTION
the alarm failed to be created, but rolling back the capacity change to avoid making too many changes in the db in case cfn rollbacks again.



