### PR TITLE
double max capacity for db

### DIFF
--- a/cdk/lib/__snapshots__/gatehouse.test.ts.snap
+++ b/cdk/lib/__snapshots__/gatehouse.test.ts.snap
@@ -317,7 +317,7 @@ exports[`The Gatehouse stack matches the snapshot 1`] = `
     "DMSReplicationConfig": {
       "Properties": {
         "ComputeConfig": {
-          "MaxCapacityUnits": 8,
+          "MaxCapacityUnits": 16,
           "MinCapacityUnits": 1,
           "ReplicationSubnetGroupId": {
             "Ref": "DMSReplicationSubnetGroup",

--- a/cdk/lib/gatehouse.ts
+++ b/cdk/lib/gatehouse.ts
@@ -535,7 +535,7 @@ export class Gatehouse extends GuStack {
 			},
 			computeConfig: {
 				minCapacityUnits: 1,
-				maxCapacityUnits: 8,
+				maxCapacityUnits: 16,
 				replicationSubnetGroupId: dmsSubnetGroup.ref,
 				vpcSecurityGroupIds: [
 					rdsSecurityGroupClients.securityGroupId,


### PR DESCRIPTION
## What does this change?

increase the max capacity in the gatehouse db to avoid any issues when we direct more traffic to it, we can reduce it once we see how much the real usage is