### PR TITLE
update netty-codec-http2 version and add dependency tree plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,6 +34,8 @@ lazy val root = (project in file("."))
         exclude ("org.scala-lang.modules", "scala-parser-combinators_2.13")
         exclude ("com.fasterxml.jackson.module", "jackson-module-scala_2.13")
         exclude ("com.typesafe", "ssl-config-core_2.13"),
+      // just to override the older version brought in by simple-configuration
+      "io.netty" % "netty-codec-http2" % "4.1.124.Final",
       "org.postgresql" % "postgresql" % "42.7.3",
       "com.okta.sdk" % "okta-sdk-api" % "15.0.0",
       "com.okta.sdk" % "okta-sdk-impl" % "15.0.0" % Runtime,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,4 @@
+addDependencyTreePlugin
 addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.2")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
 libraryDependencies += "org.vafer" % "jdeb" % "1.10" artifacts Artifact("jdeb", "jar", "jar")


### PR DESCRIPTION
## What does this change?
Ensures we get a patched version of the netty-codec-http2 library and adds the dependency tree plugin 
