### PR TITLE
add role for datalake export

### DIFF
--- a/cdk/lib/__snapshots__/gatehouse.test.ts.snap
+++ b/cdk/lib/__snapshots__/gatehouse.test.ts.snap
@@ -11,6 +11,7 @@ exports[`The Gatehouse stack matches the snapshot 1`] = `
       "GuAlarm",
       "GuRole",
       "GuRole",
+      "GuRole",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -19,6 +20,10 @@ exports[`The Gatehouse stack matches the snapshot 1`] = `
       "Default": "/account/vpc/primary/subnets/private",
       "Description": "A list of private subnets",
       "Type": "AWS::SSM::Parameter::Value<List<AWS::EC2::Subnet::Id>>",
+    },
+    "SsmParameterValueTESTidentitygatehousedbexportlocationC96584B6F00A464EAD1953AFF4B05118Parameter": {
+      "Default": "/TEST/identity/gatehouse/db-export-location",
+      "Type": "AWS::SSM::Parameter::Value<String>",
     },
     "VpcId": {
       "Default": "/account/vpc/primary/id",
@@ -37,6 +42,77 @@ exports[`The Gatehouse stack matches the snapshot 1`] = `
     },
   },
   "Resources": {
+    "AuroraS3ExportRole39002E1F": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Condition": {
+                "StringEquals": {
+                  "aws:SourceAccount": {
+                    "Ref": "AWS::AccountId",
+                  },
+                },
+              },
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "rds.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "s3:PutObject",
+                    "s3:AbortMultipartUpload",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Fn::Join": [
+                      "",
+                      [
+                        "arn:aws:s3:::",
+                        {
+                          "Ref": "SsmParameterValueTESTidentitygatehousedbexportlocationC96584B6F00A464EAD1953AFF4B05118Parameter",
+                        },
+                        "/*",
+                      ],
+                    ],
+                  },
+                },
+              ],
+              "Version": "2012-10-17",
+            },
+            "PolicyName": "writeToExportBucket",
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/gatehouse",
+          },
+          {
+            "Key": "Stack",
+            "Value": "identity",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
     "ClientSecurityGroupOutputParameter16694915": {
       "Properties": {
         "Name": "/TEST/identity/gatehouse/db-clients-security-group",
@@ -556,6 +632,17 @@ exports[`The Gatehouse stack matches the snapshot 1`] = `
     "GatehouseDbFE0B3FEE": {
       "DeletionPolicy": "Snapshot",
       "Properties": {
+        "AssociatedRoles": [
+          {
+            "FeatureName": "s3Export",
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "AuroraS3ExportRole39002E1F",
+                "Arn",
+              ],
+            },
+          },
+        ],
         "AutoMinorVersionUpgrade": true,
         "BackupRetentionPeriod": 14,
         "CopyTagsToSnapshot": true,

--- a/cdk/lib/__snapshots__/gatehouse.test.ts.snap
+++ b/cdk/lib/__snapshots__/gatehouse.test.ts.snap
@@ -25,6 +25,10 @@ exports[`The Gatehouse stack matches the snapshot 1`] = `
       "Default": "/TEST/identity/gatehouse/db-export-location",
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
+    "SsmParameterValueTESTidentitygatehouses3prefixlistidC96584B6F00A464EAD1953AFF4B05118Parameter": {
+      "Default": "/TEST/identity/gatehouse/s3-prefix-list-id",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
     "VpcId": {
       "Default": "/account/vpc/primary/id",
       "Description": "Virtual Private Cloud to run EC2 instances within. Should NOT be the account default VPC.",
@@ -1064,15 +1068,6 @@ exports[`The Gatehouse stack matches the snapshot 1`] = `
     "RDSSecurityGroupRules40FD365B": {
       "Properties": {
         "GroupDescription": "gatehouse-TEST/RDSSecurityGroupRules",
-        "SecurityGroupEgress": [
-          {
-            "CidrIp": "255.255.255.255/32",
-            "Description": "Disallow all traffic",
-            "FromPort": 252,
-            "IpProtocol": "icmp",
-            "ToPort": 86,
-          },
-        ],
         "Tags": [
           {
             "Key": "gu:cdk:version",
@@ -1117,6 +1112,24 @@ exports[`The Gatehouse stack matches the snapshot 1`] = `
         "ToPort": 5432,
       },
       "Type": "AWS::EC2::SecurityGroupIngress",
+    },
+    "RDSSecurityGroupRulestoIndirectPeer4432519F700": {
+      "Properties": {
+        "Description": "Allow database extension to outbound stream export data to S3",
+        "DestinationPrefixListId": {
+          "Ref": "SsmParameterValueTESTidentitygatehouses3prefixlistidC96584B6F00A464EAD1953AFF4B05118Parameter",
+        },
+        "FromPort": 443,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "RDSSecurityGroupRules40FD365B",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "ToPort": 443,
+      },
+      "Type": "AWS::EC2::SecurityGroupEgress",
     },
   },
 }

--- a/cdk/lib/gatehouse.ts
+++ b/cdk/lib/gatehouse.ts
@@ -11,7 +11,7 @@ import {
 	CfnReplicationConfig,
 	CfnReplicationSubnetGroup,
 } from 'aws-cdk-lib/aws-dms';
-import { Port, SecurityGroup } from 'aws-cdk-lib/aws-ec2';
+import { Peer, Port, SecurityGroup } from 'aws-cdk-lib/aws-ec2';
 import {
 	CompositePrincipal,
 	Effect,
@@ -75,6 +75,19 @@ export class Gatehouse extends GuStack {
 				vpc: vpc,
 				allowAllOutbound: false,
 			},
+		);
+
+		//the get prefixList id for our current region ( TODO maybe there's another place to get this from as this should be fixed for each region)
+		const s3PrefixListId = StringParameter.valueForStringParameter(
+			this,
+			`/${this.stage}/identity/gatehouse/s3-prefix-list-id`,
+		);
+
+		// add egress rule to allow the db to export to s3 directly
+		rdsSecurityGroupRules.addEgressRule(
+			Peer.prefixList(s3PrefixListId),
+			Port.tcp(443),
+			'Allow database extension to outbound stream export data to S3',
 		);
 
 		const rdsSecurityGroupClients = new SecurityGroup(

--- a/cdk/lib/gatehouse.ts
+++ b/cdk/lib/gatehouse.ts
@@ -186,11 +186,43 @@ export class Gatehouse extends GuStack {
 		// https://github.com/guardian/aws-account-setup/blob/42885f5d22dbee137950d4e7500bbb1d7cc1bf77/packages/cdk/lib/aws-backup.ts#L72-L76
 		Tags.of(cluster).add('devx-backup-enabled', 'true');
 
+		const exportLocation = StringParameter.valueForStringParameter(
+			this,
+			`/${this.stage}/identity/gatehouse/db-export-location`,
+		);
+
+		const exportRole = new GuRole(this, 'AuroraS3ExportRole', {
+			assumedBy: new ServicePrincipal('rds.amazonaws.com', {
+				conditions: {
+					StringEquals: {
+						'aws:SourceAccount': this.account,
+					},
+				},
+			}),
+			inlinePolicies: {
+				writeToExportBucket: new PolicyDocument({
+					statements: [
+						new PolicyStatement({
+							effect: Effect.ALLOW,
+							actions: ['s3:PutObject', 's3:AbortMultipartUpload'],
+							resources: [`arn:aws:s3:::${exportLocation}/*`],
+						}),
+					],
+				}),
+			},
+		});
+
 		// CDK currently does not support ManagerMasterUserPassword
 		// See https://github.com/aws/aws-cdk/issues/29239
 		const defaultChild = cluster.node.defaultChild as CfnDBCluster;
 		defaultChild.addOverride('Properties.ManageMasterUserPassword', true);
 		defaultChild.addOverride('Properties.MasterUserPassword', undefined);
+		defaultChild.associatedRoles = [
+			{
+				roleArn: exportRole.roleArn,
+				featureName: 's3Export',
+			},
+		];
 
 		// Output RDS Client security group as SSM parameter to be used in other stacks.
 		new StringParameter(this, 'ClientSecurityGroupOutputParameter', {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
